### PR TITLE
bug: z-index update due to new FA banner update

### DIFF
--- a/fap.css
+++ b/fap.css
@@ -1,7 +1,7 @@
 .fap-container {
 	display: flex;
 	position: fixed;
-	z-index: 9999999;
+	z-index: 999999999;
 	background-color: transparent;
 	padding: 20px;
 	pointer-events: none;

--- a/fap.css
+++ b/fap.css
@@ -1,7 +1,7 @@
 .fap-container {
 	display: flex;
 	position: fixed;
-	z-index: 9999;
+	z-index: 9999999;
 	background-color: transparent;
 	padding: 20px;
 	pointer-events: none;


### PR DESCRIPTION
Currently preview clips into other elements of the site. This should fix that.